### PR TITLE
Sungwon

### DIFF
--- a/NotePad/src/main/java/kh/edu/controller/UpdateUser.java
+++ b/NotePad/src/main/java/kh/edu/controller/UpdateUser.java
@@ -30,8 +30,8 @@ public class UpdateUser extends HttpServlet {
 			int result = service.updateUser(memberId, memberPw, memberName, loginMem.getMemberNo());
 			
 			if(result > 0) {
-				session.setAttribute("message","회원 정보 수정 성공!");
-				resp.sendRedirect("/login");
+				session.setAttribute("message","회원 정보 수정 성공! 다시 로그인 해 주세요.");
+				resp.sendRedirect("/");
 				
 				return;
 			} else {


### PR DESCRIPTION
1. 회원정보 수정을 하려면 비밀번호를 한번 더 입력하게 함.

* 다른 홈페이지 에서도 이미 로그인을 했더라도 자신의 정보를 수정하려면 한번 더 비밀번호를 입력하는 것에서 착안.

2. 비밀번호를 입력하고 확인을 누르면 DB까지 가서 조회하는 것이 아닌 Session에 저장되어있는 로그인된 유저의 정보와 비교하여 맞는지 틀린지 확인.

* 개인적인 생각으로 DB까지 조회하러 가지 않으면 조금 더 빠른 반응성이 생길 것이라 생각함.

3. 비밀번호 확인을 마쳤으면 해당 form(비밀번호 input이 포함된)을 display: none 하고, display:none 이었던 아이디, 비밀번호, 이름 수정 form 을 display:block 처리함.

* 페이지에 비밀번호 확인 form 태그 하나만 구현하고, 그 후 수정form을 위한 페이지를 새로 만들기엔 드는 노력과 시간이 많이 드는 것 같아, 착시 현상처럼 새로운 페이지에 나온 것 같이 구현 하였다.